### PR TITLE
feat: FormBridge新仕様に対応 (v13)

### DIFF
--- a/formbridge-location-picker.js
+++ b/formbridge-location-picker.js
@@ -1,88 +1,92 @@
 (function() {
-  "use strict";
-
-  // パラメータ設定
-  var useOpenStreetMap = true; // trueでOpenStreetMapを使用、falseで国土地理院の地図を使用
-  var defaultLat = 35.681236; // デフォルトの緯度　東京駅:35.681236
-  var defaultLng = 139.767125; // デフォルトの経度 東京駅:139.767125
-  var initialZoomLevel = 17; // 初期ズームレベル
-  var mapHeight = '400px'; // 地図の高さ
-  var mapWidth = '100%'; // 地図の横幅
-  var tileLayerURL = useOpenStreetMap
-                      ? 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png' // OpenStreetMapのタイルレイヤーURL
-                      : 'https://cyberjapandata.gsi.go.jp/xyz/std/{z}/{x}/{y}.png'; // 国土地理院のタイルレイヤーURL
-  var maxZoomLevel = 19; // 最大ズームレベル
-  var attribution = useOpenStreetMap
-                      ? 'Map data © <a href="https://www.openstreetmap.org/copyright" target="_blank">OpenStreetMap contributors</a>'
-                      : '© <a href="https://maps.gsi.go.jp/development/ichiran.html" target="_blank">国土地理院</a>'; // 地図データの帰属表示
-
-  // 地図のコンテナ要素を作成する関数
-  function createMapContainer() {
-    var mapDiv = document.createElement('div');
-    mapDiv.id = 'map';
-    mapDiv.style.height = mapHeight;
-    mapDiv.style.width = mapWidth;
-    return mapDiv;
-  }
-
-  // 地図を設定する関数
-  function setupMap(mapDiv, initialLat, initialLng) {
-    var map = L.map(mapDiv.id).setView([initialLat, initialLng], initialZoomLevel);
-    L.tileLayer(tileLayerURL, {
-      maxZoom: maxZoomLevel,
-      attribution: attribution
-    }).addTo(map);
-
-    var marker = L.marker([initialLat, initialLng], {draggable: true}).addTo(map);
-    marker.on('dragend', function(event) {
-      var position = marker.getLatLng();
-      updateFormFields(position.lat, position.lng);
-    });
-
-    updateFormFields(initialLat, initialLng);
-  }
-
-  // フォームが読み込まれた後の処理
-  fb.events.form.mounted = [function(state) {
-    var mapDiv = createMapContainer();
-    var formContent = document.getElementsByClassName('fb-content')[0];
-    formContent.insertBefore(mapDiv, formContent.firstChild);
-
-    // ユーザーの現在位置を取得して地図を設定
-    navigator.geolocation.getCurrentPosition(function(position) {
-      setupMap(mapDiv, position.coords.latitude, position.coords.longitude);
-    }, function(error) {
-      console.error("Geolocation error: " + error.message);
-      setupMap(mapDiv, defaultLat, defaultLng);
-    });
-
-    return state;
-  }];
-
-  // フォームが送信される前の処理
-  fb.events.form.submit = [function(state) {
-    var mapElement = document.getElementById('map');
-    if (mapElement) {
-      mapElement.style.display = 'none';
+    "use strict";
+  
+    // --- パラメータ設定 ---
+    var useOpenStreetMap = true; // trueでOpenStreetMapを使用、falseで国土地理院の地図を使用
+    var defaultLat = 35.681236;   // デフォルトの緯度（東京駅）
+    var defaultLng = 139.767125;  // デフォルトの経度（東京駅）
+    var initialZoomLevel = 17;    // 初期ズームレベル
+    var mapHeight = '400px';      // 地図の高さ
+    var mapWidth = '100%';        // 地図の横幅
+    var tileLayerURL = useOpenStreetMap
+      ? 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png'    // OpenStreetMapのタイルレイヤー
+      : 'https://cyberjapandata.gsi.go.jp/xyz/std/{z}/{x}/{y}.png'; // 国土地理院のタイルレイヤー
+    var maxZoomLevel = 19;        // 最大ズームレベル
+    var attribution = useOpenStreetMap
+      ? 'Map data © <a href="https://www.openstreetmap.org/copyright" target="_blank">OpenStreetMap contributors</a>'
+      : '© <a href="https://maps.gsi.go.jp/development/ichiran.html" target="_blank">国土地理院</a>'; // 帰属表示
+  
+    // --- 地図のコンテナ要素を作成 ---
+    function createMapContainer() {
+      var mapDiv = document.createElement('div');
+      mapDiv.id = 'map';
+      mapDiv.style.height = mapHeight;
+      mapDiv.style.width = mapWidth;
+      return mapDiv;
     }
-    return state;
-  }];
-
-  // 緯度と経度をフォームに設定し、changeイベントを発火させる関数
-  function updateFormFields(lat, lng) {
-    var latitudeField = fb.getElementByCode('latitude');
-    var longitudeField = fb.getElementByCode('longitude');
-
-    if (latitudeField && longitudeField) {
-      var latitudeInput = latitudeField.getElementsByTagName('input')[0];
-      var longitudeInput = longitudeField.getElementsByTagName('input')[0];
-
-      latitudeInput.value = lat.toFixed(6);
-      longitudeInput.value = lng.toFixed(6);
-
-      var event = new Event('change', { bubbles: true });
-      latitudeInput.dispatchEvent(event);
-      longitudeInput.dispatchEvent(event);
+  
+    // --- フィールド（緯度・経度）を更新 ---
+    // 新仕様のAPI: context.setFieldValue(fieldCode, value) を使用
+    function updateFormFields(context, lat, lng) {
+      context.setFieldValue('latitude', lat.toFixed(6));
+      context.setFieldValue('longitude', lng.toFixed(6));
     }
-  }
-})();
+  
+    // --- 地図を設定 ---
+    function setupMap(context, mapDiv, initialLat, initialLng) {
+      var map = L.map(mapDiv.id).setView([initialLat, initialLng], initialZoomLevel);
+  
+      L.tileLayer(tileLayerURL, {
+        maxZoom: maxZoomLevel,
+        attribution: attribution
+      }).addTo(map);
+  
+      // マーカーのドラッグ終了時にフィールドを更新
+      var marker = L.marker([initialLat, initialLng], {draggable: true}).addTo(map);
+      marker.on('dragend', function() {
+        var position = marker.getLatLng();
+        updateFormFields(context, position.lat, position.lng);
+      });
+  
+      // 初期表示時点でもフィールド更新
+      updateFormFields(context, initialLat, initialLng);
+    }
+  
+    // --- フォーム表示時(form.show) ---
+    // 旧： fb.events.form.mounted → 新： formBridge.events.on('form.show', ...)
+    formBridge.events.on('form.show', function(context) {
+      // 地図コンテナをDOMに挿入
+      var mapDiv = createMapContainer();
+  
+      // 新仕様のCSSクラスを使ってフォーム要素を取得（例: fb-custom--content）
+      // 必要に応じて従来の document.getElementsByClassName(...) から置き換え
+      var formContent = document.querySelector('.fb-custom--content');
+      if (!formContent) {
+        // 万一取得できなかった場合、既存と同じクラス名でフォールバック
+        formContent = document.getElementsByClassName('fb-content')[0];
+      }
+      formContent.insertBefore(mapDiv, formContent.firstChild);
+  
+      // ユーザーの現在位置を取得して地図を設定
+      navigator.geolocation.getCurrentPosition(function(position) {
+        setupMap(context, mapDiv, position.coords.latitude, position.coords.longitude);
+      }, function(error) {
+        console.error("Geolocation error: " + error.message);
+        setupMap(context, mapDiv, defaultLat, defaultLng);
+      });
+    });
+  
+    // --- フォーム送信時(form.submit) ---
+    // 旧： fb.events.form.submit → 新： formBridge.events.on('form.submit', ...)
+    formBridge.events.on('form.submit', function(context) {
+      var mapElement = document.getElementById('map');
+      if (mapElement) {
+        // 送信直前に地図を非表示にする例
+        mapElement.style.display = 'none';
+      }
+      // 必要に応じて、回答送信を止めたいときは context.preventDefault() を呼び出す
+      // context.preventDefault();
+    });
+  
+  })();
+  


### PR DESCRIPTION
2025年2月のフォームブリッジの仕様変更（2025-02-04 | 1.31.0）に伴い動作しなくなっていたため、修正。
仕様は、https://form.kintoneapp.com/help/customize/v2 に公開されており、これに合わせた。

# 変更内容
- fb.events.form.* から formBridge.events.on(...) へ変更
- context.setFieldValue によるフィールド更新を導入
- DOM直接操作を廃止

# テスト
- 2025年2月版FormBridgeで動作確認済
- フォーム上で緯度経度が正しく更新されることを確認
- 画面サイズ変更、国土地理院地図変更の動作を確認